### PR TITLE
added serialization to FilterType

### DIFF
--- a/python/lsst/ts/wep/Utility.py
+++ b/python/lsst/ts/wep/Utility.py
@@ -16,6 +16,62 @@ class FilterType(Enum):
     Y = 6
     REF = 7
 
+    @staticmethod
+    def fromString(arg):
+        """Instantiate the FilterType based on a string that maps 
+        one-to-one with the filters.
+
+        Parameters
+        ----------
+        arg : str
+            The string corresponding to the filter.
+
+        Returns
+        -------
+        FilterType 
+            The FilterType corresponding to the string. 
+        """
+        char = arg.strip().lower()
+        string2Filter = {
+            "u": FilterType.U,
+            "g": FilterType.G,
+            "r": FilterType.R,
+            "i": FilterType.I,
+            "z": FilterType.Z,
+            "y": FilterType.Y,
+            "ref": FilterType.REF
+        }
+        return string2Filter[char]
+
+    def toString(self):
+        """Represent the FilterType as a string.
+
+        Returns
+        -------
+        str
+            representation of self.
+        """
+        return str(self)
+
+    def __str__(self):
+        """Represent the FilterType as a string.
+
+        Returns
+        -------
+        str
+            representation of self.
+        """
+        filter2String = {
+            FilterType.U: "u",
+            FilterType.G: "g",
+            FilterType.R: "r",
+            FilterType.I: "i",
+            FilterType.Z: "z",
+            FilterType.Y: "y",
+            FilterType.REF: "ref",
+        }
+        return filter2String[self]
+
 
 class CamType(Enum):
     LsstCam = 1

--- a/tests/testUtility.py
+++ b/tests/testUtility.py
@@ -7,6 +7,13 @@ from lsst.ts.wep.Utility import abbrevDectectorName, expandDetectorName, \
 class TestUtility(unittest.TestCase):
     """Test the Utility functions."""
 
+    def testSerializingAndUnserializingFilterType(self):
+
+        filt = FilterType.fromString('y')
+        self.assertEqual(filt, FilterType.Y)
+        string = filt.toString()
+        self.assertEqual(string, 'y')
+
     def testAbbrevDectectorName(self):
 
         sciSensorName = "R:2,2 S:1,1"


### PR DESCRIPTION
Serialization is necessary for some conversions done in wep-phosim. It is also handy in other contexts.  